### PR TITLE
Update the example runyi script in installing.md

### DIFF
--- a/pages/installing.md
+++ b/pages/installing.md
@@ -73,7 +73,7 @@ to create an alias or small script for this, along the lines of:
 ```
 #!/usr/bin/env bash
 YI_DIR=$HOME/programming/yi/yi
-env CABAL_SANDBOX_CONFIG=$YI_DIR/cabal.sandbox.config cabal exec $YI_DIR/dist/build/yi/yi "$@"
+env CABAL_SANDBOX_CONFIG=$YI_DIR/cabal.sandbox.config cabal exec $YI_DIR/dist/build/yi/yi -- "$@"
 ```
 
 The `"$@"` part means that all the


### PR DESCRIPTION
cabal exec requires arguments to the executed command to be preceded by "--". Otherwise, they are interpreted as arguments for cabal exec itself.

See:

$ cabal exec -h
