### PR TITLE
Update installing.md

### DIFF
--- a/pages/installing.md
+++ b/pages/installing.md
@@ -57,13 +57,12 @@ you'll get config compilation errors due to missing modules.
 To sandbox, navigate to your source yi directory. For me it's
 `~/programming/yi/yi`.
 
-We then setup a cabal sandbox following instructions from the
-[cabal userguide](http://www.haskell.org/cabal/users-guide/installing-packages.html#sandboxes-basic-usage):
+We then setup a cabal sandbox:
 
 ```
 $ cabal sandbox init
 $ cabal install --only-dependencies
-$ cabal build
+$ cabal install
 ```
 
 From cabal-install 1.20, Yi can be launched in an environment using the


### PR DESCRIPTION
Replaced cabal build with cabal install in the sandbox-instructions. It turns out that cabal build doesn't add the yi package to the local package db.
