### PR TITLE
Fix precedence bug

### DIFF
--- a/posts/2014-09-05-oop/index.html
+++ b/posts/2014-09-05-oop/index.html
@@ -94,7 +94,7 @@ proto <span class="fu">=</span> \self <span class="ot">-&gt;</span> <span class=
 <div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">abc <span class="fu">=</span> fix proto</code></pre></div>
 <p>Of course, this works only because Haskell is lazy (and because the original definition did not introduce an infinite recursion in the first place). If the fields of the record are marked strict, this ceases to work.</p>
 <p>Given that definition, it is easy to customize the value as follows:</p>
-<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">customizedProto <span class="fu">=</span> \self <span class="ot">-&gt;</span> proto self {
+<div class="sourceCode"><pre class="sourceCode haskell"><code class="sourceCode haskell">customizedProto <span class="fu">=</span> \self <span class="ot">-&gt;</span> (proto self) {
    c <span class="fu">=</span> userFunction (a self) (b self)
  }
 

--- a/yi-documentation/posts/2014-09-05-oop.md
+++ b/yi-documentation/posts/2014-09-05-oop.md
@@ -78,7 +78,7 @@ If the fields of the record are marked strict, this ceases to work.
 Given that definition, it is easy to customize the value as follows:
 
 ~~~ haskell
-customizedProto = \self -> proto self {
+customizedProto = \self -> (proto self) {
    c = userFunction (a self) (b self)
  }
 


### PR DESCRIPTION
Subtle bug with the OO post: `proto self { ... }` is parsed as `proto (self { ... })`, but what is meant is `(proto self) { ... }`. With the former, we can't call overridden methods from the overriding object.

Minimal example:
```hs
data Thing = Thing {
  a :: String,
  b :: String
} deriving (Show)

proto :: Thing -> Thing
proto self = Thing {
  a = "original a " ++ b self,
  b = "original b"
}

base :: Thing
base = fix proto

proto' :: Thing -> Thing
proto' self = (proto self) { b = "new b" }

derived :: Thing
derived = fix proto'

-- without explicit parens, `b derived` wrongly returns "original b";
-- with, it returns "new b"
```